### PR TITLE
Fix processing of async chunks from save_response_to_file requests

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -25,6 +25,10 @@ defmodule HTTPotion.Base do
         IO.iodata_to_binary body
       end
 
+      def process_response_chunk(body = {:file, filename}) do
+        IO.iodata_to_binary(filename)
+      end
+
       def process_response_chunk(chunk) do
         IO.iodata_to_binary chunk
       end


### PR DESCRIPTION
an asynchronous request with the ibrowse option `:save_response_to_file` enabled resulted in a response with a tuple body instead of iodata. `process_response_chunk/1` then tried to stuff this tuple into `IO.iodata_to_binary`, which crashed with an argument error.
